### PR TITLE
Support indent_size and max_line_length from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{py,talon}]
+charset = utf-8
+indent_style = space
+indent_size = 4
+max_line_length = 88

--- a/poetry.lock
+++ b/poetry.lock
@@ -163,6 +163,18 @@ more-itertools = "*"
 dev = ["build", "pytest", "sphinx", "sphinx-bootstrap-theme", "twine"]
 
 [[package]]
+name = "editorconfig"
+version = "0.12.3"
+description = "EditorConfig File Locator and Interpreter for Python"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "EditorConfig-0.12.3-py3-none-any.whl", hash = "sha256:6b0851425aa875b08b16789ee0eeadbd4ab59666e9ebe728e526314c4a2e52c1"},
+    {file = "EditorConfig-0.12.3.tar.gz", hash = "sha256:57f8ce78afcba15c8b18d46b5170848c88d56fd38f05c2ec60dbbfcb8996e89e"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.0.0rc9"
 description = "Backport of PEP 654 (exception groups)"
@@ -867,4 +879,4 @@ test = ["bumpver", "pytest", "pytest-benchmark", "pytest-golden"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.8"
-content-hash = "54f74fe734246360c52f71aae177619b82d9cab16c2fa9cf296bb3c43e6be240"
+content-hash = "25d34857d5573baeb6fc60ce21d21c1090f412da57f2014d0e77fe81950c352b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ python = "^3.9.8"
 click = "^8.1.3"
 bumpver = { version = "*", optional = true }
 doc-printer = "^0.13.1"
+editorconfig = "^0.12.3"
 pytest = { version = "^7.1.2", optional = true }
 pytest-benchmark = { version = ">=3.4.1,<5.0.0", optional = true }
 pytest-golden = { version = "^0.2.2", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ pytest = { version = "^7.1.2", optional = true }
 pytest-benchmark = { version = ">=3.4.1,<5.0.0", optional = true }
 pytest-golden = { version = "^0.2.2", optional = true }
 tree-sitter-talon = "^1006.3.2.0"
+# Prevent poetry 1.3 from removing setuptools
+setuptools = "*"
 
 [tool.poetry.extras]
 test = ["bumpver", "pytest", "pytest-benchmark", "pytest-golden"]

--- a/talonfmt/__init__.py
+++ b/talonfmt/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 from doc_printer import DocRenderer, SimpleDocRenderer, SimpleLayout, SmartDocRenderer
 from tree_sitter_talon import Node, parse
 
+from .editorconfig import get_indent_size, get_max_line_length
 from .formatter import EmptyMatchContext, TalonFormatter
 
 __version__: str = "1.8.1"
@@ -15,7 +16,7 @@ def talonfmt(
     filename: Optional[str] = None,
     encoding: str = "utf-8",
     safe: Optional[bool] = None,
-    indent_size: int = 4,
+    indent_size: Optional[int] = None,
     max_line_width: Optional[int] = None,
     align_match_context: bool = False,
     align_match_context_at: Optional[int] = None,
@@ -26,6 +27,20 @@ def talonfmt(
     empty_match_context: str = "keep",
     preserve_blank_lines: tuple[str, ...] = ("body", "command"),
 ):
+    # Get max_line_width from .editorconfig
+    if filename is not None and max_line_width is None:
+        max_line_width = get_max_line_length(filename)
+        print(f"Got max_line_width={max_line_width} from .editorconfig")
+
+    # Get indent_size from .editorconfig
+    if filename is not None and indent_size is None:
+        indent_size = get_indent_size(filename)
+        print(f"Got indent_size={indent_size} from .editorconfig")
+
+    # Set default indent_size
+    if indent_size is None:
+        indent_size = 4
+
     # Parse (if necessary):
     if isinstance(contents, Node):
         ast = contents

--- a/talonfmt/cli.py
+++ b/talonfmt/cli.py
@@ -25,13 +25,12 @@ from . import __version__, talonfmt
 )
 @click.option(
     "--indent-size",
-    type=int,
-    default=4,
+    type=int,  # Optional[int]
     show_default=True,
 )
 @click.option(
     "--max-line-width",
-    type=int,
+    type=int,  # Optional[int]
     show_default=True,
 )
 @click.option(
@@ -105,7 +104,7 @@ def cli(
     *,
     path: tuple[Path, ...],
     safe: bool = True,
-    indent_size: int,
+    indent_size: Optional[int],
     max_line_width: Optional[int],
     align_match_context: bool,
     align_match_context_at: Optional[int],

--- a/talonfmt/editorconfig.py
+++ b/talonfmt/editorconfig.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from typing import Dict, Optional
+
+try:
+    from editorconfig import EditorConfigError, get_properties
+
+    def get_editorconfig(file: str) -> Dict[str, str]:
+        try:
+            return get_properties(Path(file).absolute())
+        except EditorConfigError:
+            return {}
+
+except ModuleNotFoundError as e:
+    if e.name != "editorconfig":
+        raise e
+
+    def get_editorconfig(file: str) -> Dict[str, str]:
+        return {}
+
+
+def get_indent_size(file: str) -> Optional[int]:
+    indent_size = get_editorconfig(file).get("indent_size", None)
+    if indent_size is not None:
+        return int(indent_size)
+    else:
+        return None
+
+
+def get_max_line_length(file: str) -> Optional[int]:
+    max_line_length = get_editorconfig(file).get("max_line_length", None)
+    if max_line_length is not None:
+        return int(max_line_length)
+    else:
+        return None


### PR DESCRIPTION
Pulls the default values for the `--indent_size` and `--max_line_width` options from the `indent_size` and `max_line_length` fields of the `.editorconfig` file, if present.