### PR TITLE
__init__.py: typo fix

### DIFF
--- a/src/talonfmt/__init__.py
+++ b/src/talonfmt/__init__.py
@@ -132,6 +132,6 @@ def talonfmt(
         # assert: formatting twice results in the same output
         assert formatted == render(
             ast_for_formatted, verbose=False
-        ), f"Formatting {filename or 'input'} twice gives a differrent result."
+        ), f"Formatting {filename or 'input'} twice gives a different result."
 
     return formatted

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,6 +1,7 @@
 def test_talonfmt_version() -> None:
-    import talonfmt
     import subprocess
+
+    import talonfmt
 
     actual_output = (
         subprocess.check_output(["talonfmt", "--version"]).decode("utf-8").strip()


### PR DESCRIPTION
Just happen to notice this on the command line